### PR TITLE
fix: bump adapter/cli/core versions + updated prepare command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,26 +5,25 @@
   "requires": true,
   "dependencies": {
     "@sasjs/adapter": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-2.8.5.tgz",
-      "integrity": "sha512-S0wCOjiu/OYqfyqK6zUFOQNrOK6crmhprzbF1Ed2pCcuAK9sIF1dGGXHUrbYE0vfXG54yGIBv3LS51C9zkiW4Q==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-2.9.1.tgz",
+      "integrity": "sha512-HO8g9dbxAXY2mvImtCcgU7+qxNSO8Icpq8jxRKWTj1tyGKjACMBY0IcIvYDPGFr+4wrw82mmF9kaRGcjJQpLqg==",
       "requires": {
-        "@sasjs/utils": "^2.20.1",
+        "@sasjs/utils": "^2.27.1",
         "axios": "^0.21.1",
         "axios-cookiejar-support": "^1.0.1",
         "form-data": "^4.0.0",
         "https": "^1.0.0",
-        "tough-cookie": "^4.0.0",
-        "url": "^0.11.0"
+        "tough-cookie": "^4.0.0"
       }
     },
     "@sasjs/cli": {
-      "version": "2.33.3",
-      "resolved": "https://registry.npmjs.org/@sasjs/cli/-/cli-2.33.3.tgz",
-      "integrity": "sha512-y1uFM5MEE6eoKLrPUJbweDt4njSy9Y3CS5w5/U2xwNbiAyhiPXgkwCHjCQ8Qg+0rQnMvyNEn6qJuJZ3udc6T7w==",
+      "version": "2.35.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/cli/-/cli-2.35.0.tgz",
+      "integrity": "sha512-jc/fbbZgAn40Fkj/1ZPiZNPXghpG4IV+mEH8UUDozV3+0SGB7RGYAt9oXtemQWf3Jq5VDBJxKr0kAhkxgJfa0A==",
       "requires": {
-        "@sasjs/adapter": "2.8.9",
-        "@sasjs/core": "2.35.3",
+        "@sasjs/adapter": "2.8.13",
+        "@sasjs/core": "2.35.4",
         "@sasjs/lint": "1.11.2",
         "@sasjs/utils": "2.23.3",
         "@types/url-parse": "1.4.3",
@@ -48,24 +47,23 @@
       },
       "dependencies": {
         "@sasjs/adapter": {
-          "version": "2.8.9",
-          "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-2.8.9.tgz",
-          "integrity": "sha512-8UChcZlqqlmaMMaKOCr2Bc1h+i2KVDY0FINlPXQN5PdAgEMd8dbxI2p9bsiI1yjYjOBO9LuMl7B79/mwYCtyEw==",
+          "version": "2.8.13",
+          "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-2.8.13.tgz",
+          "integrity": "sha512-N/KnCKg0tVFoHBOFFem4VDJLdd/pOqivw36qb2EiS6j4UqKjiVHRsRP+9T1fHLHg5Z/AEU4URGkE8u3ayOxSbw==",
           "requires": {
-            "@sasjs/utils": "^2.21.0",
+            "@sasjs/utils": "^2.23.2",
             "axios": "^0.21.1",
             "axios-cookiejar-support": "^1.0.1",
             "form-data": "^4.0.0",
             "https": "^1.0.0",
-            "jwt-decode": "^3.1.2",
             "tough-cookie": "^4.0.0",
             "url": "^0.11.0"
           }
         },
         "@sasjs/core": {
-          "version": "2.35.3",
-          "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-2.35.3.tgz",
-          "integrity": "sha512-3o5PU6DkihpA+Aibt1lRy4USqJI0VFa+wNsKCD+bUD2DLZICU3JablZQxwAPH70VWJGXAUJtDFj0T/iRo5Devg=="
+          "version": "2.35.4",
+          "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-2.35.4.tgz",
+          "integrity": "sha512-Exr3+yRdvacKvbXQoi1RfGHi5NtZUkc7RwFNkemHTFXLYaIzPI8CGSCaQmKkwM1UteOJly2e2pw2YT6kHNY1NA=="
         },
         "@sasjs/utils": {
           "version": "2.23.3",
@@ -85,9 +83,9 @@
       }
     },
     "@sasjs/core": {
-      "version": "2.35.4",
-      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-2.35.4.tgz",
-      "integrity": "sha512-Exr3+yRdvacKvbXQoi1RfGHi5NtZUkc7RwFNkemHTFXLYaIzPI8CGSCaQmKkwM1UteOJly2e2pw2YT6kHNY1NA=="
+      "version": "2.35.5",
+      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-2.35.5.tgz",
+      "integrity": "sha512-h3jzN05QQTVS3PWSOkNGPbCndkBt3JchH/TInOGAyXWjQBHPVHHTYzDCPM4CtsmgpdbHU+GJ9q1cc5xacNtRXQ=="
     },
     "@sasjs/lint": {
       "version": "1.11.2",
@@ -98,16 +96,19 @@
       }
     },
     "@sasjs/utils": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.21.0.tgz",
-      "integrity": "sha512-ehRF1VHBiF8FNg2w4VocjBlb+ZkyMasUZOvUn19bsdqpF0otJVYu66gFOJF0rIpykh/vbpLi6dhqYOxgCRAYIw==",
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-2.27.1.tgz",
+      "integrity": "sha512-CYTQwEj89cc7H3tGiQQcyDkZYaWRc1HZJpOF8o2RHYS37fIAOy0SyyJdq6mcQ74Nb1u5AmFXPFIvnRCMEcTYeQ==",
       "requires": {
+        "@types/fs-extra": "^9.0.11",
         "@types/prompts": "^2.0.13",
         "chalk": "^4.1.1",
         "cli-table": "^0.3.6",
         "consola": "^2.15.0",
         "fs-extra": "^10.0.0",
+        "jwt-decode": "^3.1.2",
         "prompts": "^2.4.1",
+        "rimraf": "^3.0.2",
         "valid-url": "^1.0.9"
       }
     },
@@ -116,15 +117,23 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
     },
+    "@types/fs-extra": {
+      "version": "9.0.12",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.12.tgz",
+      "integrity": "sha512-I+bsBr67CurCGnSenZZ7v94gd3tc3+Aj2taxMT4yu4ABLuOgOjeFxX3dokG24ztSRg5tnT00sL8BszO7gSMoIw==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/node": {
-      "version": "15.12.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.4.tgz",
-      "integrity": "sha512-zrNj1+yqYF4WskCMOHwN+w9iuD12+dGm0rQ35HLl9/Ouuq52cEtd0CH9qMgrdNmi5ejC1/V7vKEXYubB+65DkA=="
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.0.tgz",
+      "integrity": "sha512-HrJuE7Mlqcjj+00JqMWpZ3tY8w7EUd+S0U3L1+PQSWiXZbOgyQDvi+ogoUxaHApPJq5diKxYBQwA3iIlNcPqOg=="
     },
     "@types/prompts": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.0.13.tgz",
-      "integrity": "sha512-jwMOIGy49VruR/gYehhJYgpVzB+EVpEE7t7j9m1oTo4HMpOe7KmsyqdBuoxAzA5B4caUgx0cKrWr7wUEqMXJ7Q==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.0.14.tgz",
+      "integrity": "sha512-HZBd99fKxRWpYCErtm2/yxUZv6/PBI9J7N4TNFffl5JbrYMHBwF25DjQGTW3b3jmXq+9P6/8fCIb2ee57BFfYA==",
       "requires": {
         "@types/node": "*"
       }
@@ -326,6 +335,12 @@
       "version": "2.15.3",
       "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
       "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw=="
+    },
+    "cpy-t": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/cpy-t/-/cpy-t-1.1.5.tgz",
+      "integrity": "sha512-STf/z7ftWO3+0On3LVaeZUU0ihxVfHf0HCd6PMA4kxqEAZH8wl9+hqgdTRYKnc1hH8ejt90t9zHYvYFafbBH3Q==",
+      "dev": true
     },
     "cssom": {
       "version": "0.4.4",
@@ -640,9 +655,9 @@
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
     },
     "is-core-module": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
-      "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
+      "integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
       "requires": {
         "has": "^1.0.3"
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "deploy": "rsync -avhe ssh ./src/* --delete $SSH_ACCOUNT:$DEPLOY_PATH",
-    "prepare": "cp node_modules/@sasjs/adapter/index.js src/sasjs.js"
+    "prepare": "cpy-t node_modules/@sasjs/adapter/index.js src/sasjs.js"
   },
   "keywords": [
     "SAS",
@@ -16,8 +16,11 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@sasjs/adapter": "^2.8.5",
-    "@sasjs/cli": "^2.33.3",
-    "@sasjs/core": "^2.35.4"
+    "@sasjs/adapter": "^2.9.1",
+    "@sasjs/cli": "^2.35.0",
+    "@sasjs/core": "^2.35.5"
+  },
+  "devDependencies": {
+    "cpy-t": "^1.1.5"
   }
 }


### PR DESCRIPTION
Bumped to latest versions:
- sasjs/cli
- sasjs/adapter
- sasjs/core

Updated `prepare` step, to have windows friendly environment.